### PR TITLE
packer: clean up the ssh keys

### DIFF
--- a/grist.pkr.hcl
+++ b/grist.pkr.hcl
@@ -47,19 +47,21 @@ source "amazon-ebs" "ubuntu_aws" {
     most_recent = true
     owners      = ["099720109477"] # Canonical's official Ubuntu AMIs
   }
-  ssh_username   = "ubuntu"
-  access_key     = var.aws_access_key
-  secret_key     = var.aws_secret_key
-  user_data_file = ""
+  ssh_username              = "ubuntu"
+  access_key                = var.aws_access_key
+  secret_key                = var.aws_secret_key
+  user_data_file            = ""
+  ssh_clear_authorized_keys = true
 }
 
 source "digitalocean" "ubuntu_do" {
-  image         = var.do_image
-  region        = "nyc3"
-  size          = "s-1vcpu-1gb"
-  api_token     = var.do_token
-  ssh_username  = "root"
-  snapshot_name = "grist-marketplace-{{timestamp}}"
+  image                     = var.do_image
+  region                    = "nyc3"
+  size                      = "s-1vcpu-1gb"
+  api_token                 = var.do_token
+  ssh_username              = "root"
+  snapshot_name             = "grist-marketplace-{{timestamp}}"
+  ssh_clear_authorized_keys = true
 }
 
 build {


### PR DESCRIPTION
The docs say this is purely cosmetic, because the keys are deleted from the host (i.e. the machine we ran `packer build .` from), but they still show up in the guest (the virtual machine image we are building).

  https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs#communicator-configuration

The AWS image checker complains about these keys being there, so let's be explicit about cleaning them up.