### PR TITLE
Miscellaneous usability fixes

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -1,3 +1,6 @@
+( You may also read this document online at
+  https://github.com/gristlabs/grist-pack/tree/main/dist )
+
 # Grist Cloud Distribution
 
 This a comprehensive distribution of Grist made with Docker Compose.

--- a/dist/README.md
+++ b/dist/README.md
@@ -106,9 +106,12 @@ The following environment variables can be configured:
 * `PERSIST_DIR`
 * `SECRETS_DIR`
 
-They are documented in the generated `.env` file. They may be changed,
-but some require regenerating files in the directory defined by
-`PERSIST_DIR`. Here are some cases:
+They are documented in the generated `.env` file. 
+
+## Changing configuration variables
+
+Variables may be changed, but some require regenerating files in the
+directory defined by `PERSIST_DIR`. Here are some cases:
 
 * `USERNAME`, `PASSWORD`: If you change either of these, you will need
   to delete Authelia's `users_database.yaml` file and re-run the
@@ -124,6 +127,18 @@ but some require regenerating files in the directory defined by
   delete your existing certificates under `traefik-certs`, namely
   `grist.cert` and `grist.key`, and re-run the bootstrap script to
   create a new certificate.
+
+Additionally, it's possible to reset the environment to a mostly
+pristine state:
+
+```sh
+./bin/reset-environment
+```
+
+This will stop Grist, back up your generated files, and save your
+current configuration variables, if any, into the `~/.env` file. You
+may then inspect or modify your variables and re-run the bootstrap
+script again.
 
 # Updating Grist
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -124,3 +124,42 @@ but some require regenerating files in the directory defined by
   delete your existing certificates under `traefik-certs`, namely
   `grist.cert` and `grist.key`, and re-run the bootstrap script to
   create a new certificate.
+
+# Updating Grist
+
+To update to the latest Grist version at any time, first stop Grist.
+
+If using systemd:
+
+```sh
+sudo systemctl disable --now grist
+```
+
+Otherwise:
+
+```sh
+docker compose down
+```
+
+Then pull the latest changes:
+
+```sh
+docker compose pull
+```
+
+Once that completes successfully, restart Grist.
+
+If using systemd:
+
+```sh
+sudo systemctl enable --now grist
+```
+
+Otherwise:
+
+```sh
+docker compose up
+```
+
+You may then confirm as usual from the Grist web interface that the
+latest version is now available.

--- a/dist/README.md
+++ b/dist/README.md
@@ -4,7 +4,8 @@
 # Grist Cloud Distribution
 
 This a comprehensive distribution of Grist made with Docker Compose.
-It combines the following tools as services in Compose:
+Along with Grist, it combines the following tools as services in
+Compose:
 
 * [Traefik](https://github.com/traefik/traefik) as a reverse proxy and for TLS termination (handling HTTPS)
 * [Authelia](https://github.com/authelia/authelia) as an email + password manager, optionally with 2FA and
@@ -119,6 +120,7 @@ but some require regenerating files in the directory defined by
   regenerate `users_database.yaml` as above, and possibly reassign
   ownership of documents in Grist to the new email.
 * `GRIST_DOMAIN`: If `GRIST_DOMAIN` is changed and you are using the
-  automatically-created self-signed certificates, you will need to
-  delete your existing certificate and re-run the bootstrap script to
+  automatically created self-signed certificates, you will need to
+  delete your existing certificates under `traefik-certs`, namely
+  `grist.cert` and `grist.key`, and re-run the bootstrap script to
   create a new certificate.

--- a/dist/README.md
+++ b/dist/README.md
@@ -85,7 +85,7 @@ The logs from all of the Grist Docker services will also be available
 in systemd's journal service, for example:
 
 ```sh
-sudo journalctl -xeu grist
+sudo journalctl -xeu grist --all
 ```
 
 # Configuration

--- a/dist/README.md
+++ b/dist/README.md
@@ -70,14 +70,14 @@ If everything looks fine, you may interrupt Compose (hit Ctrl-C), run
 `docker compose down` and use systemd to handle the Grist Docker process:
 
 ```sh
-sudo systemd enable --now grist
+sudo systemctl enable --now grist
 ```
 
 This will ensure that Grist restarts cleanly if you need to stop or
 restart the server it's running on.
 
 Once you have enabled the systemd unit, you can also run
-`systemctl stop grist` or `systemctl start grist` in
+`sudo systemctl stop grist` or `sudo systemctl start grist` in
 order to start or stop the Grist Docker services like any other
 systemd unit.
 

--- a/dist/bin/bootstrap-environment
+++ b/dist/bin/bootstrap-environment
@@ -16,7 +16,7 @@ function getSecret {
 }
 
 function generateSecureString {
-  getSecret "$(docker run authelia/authelia:4 authelia crypto rand --charset=rfc3986 --length="$1")"
+  getSecret "$(docker run --rm authelia/authelia:4 authelia crypto rand --charset=rfc3986 --length="$1")"
 }
 
 function setUpDirStructure {
@@ -75,14 +75,14 @@ function setSecretsVariables {
   export GRIST_OIDC_IDP_CLIENT_SECRET=$(generateSecureString 64)
 
   # Generates the OIDC secret key for the Dex client
-  export CLIENT_SECRET_OUTPUT="$(docker run authelia/authelia:4 authelia crypto hash generate pbkdf2 \
+  export CLIENT_SECRET_OUTPUT="$(docker run --rm authelia/authelia:4 authelia crypto hash generate pbkdf2 \
     --variant sha512 --random --random.length 72 --random.charset rfc3986)"
   export DEX_CLIENT_SECRET=$(getSecret "$(grep 'Password' <<< $CLIENT_SECRET_OUTPUT)")
 
   getSecret "$(grep 'Digest' <<< $CLIENT_SECRET_OUTPUT)" > "$SECRETS_DIR/DEX_CLIENT_SECRET_DIGEST"
 
   # Generate JWT certificates Authelia needs for OIDC
-  docker run -v $SECRETS_DIR/authelia-certs:/certs -u $(id -u):$(id -g) \
+  docker run --rm -v $SECRETS_DIR/authelia-certs:/certs -u $(id -u):$(id -g) \
     authelia/authelia:4 authelia crypto certificate rsa generate -d /certs
 
 }
@@ -114,7 +114,7 @@ function setUpAdminUser {
     return
   else
     echo "${green}Writing initial admin user credentials${normal}"
-    export PASSWORD_HASH=$(docker run authelia/authelia:4 authelia crypto hash generate argon2 --password "$PASSWORD" | cut -f 2 -d' ')
+    export PASSWORD_HASH=$(docker run --rm authelia/authelia:4 authelia crypto hash generate argon2 --password "$PASSWORD" | cut -f 2 -d' ')
     envsubst < $CONFIG_DIR/authelia/users_database.yml.template > $dbfile
   fi
 }

--- a/dist/bin/bootstrap-environment
+++ b/dist/bin/bootstrap-environment
@@ -57,7 +57,8 @@ function setConfigVariables {
 
 function setSecretsVariables {
   if [[ -e $PERSIST_DIR/authelia/db.sqlite3 ]]; then
-    echo "${red}Authelia's database has already been populated. "
+    echo "${red}Authelia's main configuration database has "\
+         "already been populated. "
     echo "Not generating new secrets.${normal}"
 
     export GRIST_OIDC_IDP_CLIENT_ID

--- a/dist/bin/reset-environment
+++ b/dist/bin/reset-environment
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Helper script to safely get out of some bad situations
+
+set -e
+
+CONFIG_DIR=$(realpath $(dirname $0)/../config)
+ENV_DIR=$(realpath $CONFIG_DIR/..)
+
+green=$(tput setaf 2)
+normal=$(tput sgr0)
+
+if [[ -e $ENV_DIR/.env ]]; then
+  echo "${green}Reusing existing environment variables from ${ENV_DIR}${normal}"
+  source .env
+fi
+
+
+if [[ ! -z $(docker ps --all --quiet) ]]; then
+  # Bring down docker, sometimes it's still lingering around
+  echo "${green}Bringing down docker compose...${normal}"
+  docker compose down
+  sudo systemctl disable --now grist
+fi
+
+PERSIST_DIR=${PERSIST_DIR:-${ENV_DIR}/persist}
+
+if [[ -e $PERSIST_DIR ]]; then
+  # Sometimes ~/persist stays up and ends up being owned by root, can
+  # happen if the Docker process ended up creating the directory
+  # instead of the bootstrap script
+  echo "${green}Ensuring that $PERSIST_DIR is owned by the current user${normal}"
+  sudo chown -R $(id -u):$(id -g) $PERSIST_DIR
+  # Unix time
+  timestamp=$(date +%s)
+  NEW_PERSIST_DIR=${PERSIST_DIR}-${timestamp}.bak
+  echo "${green}Backing up persist directory to ${NEW_PERSIST_DIR}${normal}"
+  mv $PERSIST_DIR $NEW_PERSIST_DIR
+  PERSIST_DIR=$NEW_PERSIST_DIR
+
+  if [[ -e $PERSIST_DIR/env-vars ]]; then
+    echo "${green}Salvaging old environment variables as .env file${normal}"
+    rm -f $ENV_DIR/.env
+    cp $PERSIST_DIR/env-vars $ENV_DIR/.env
+    SALVAGED_VARS="yes"
+  fi
+
+fi
+
+echo "Environment reset complete. Inspect backed-up files, and re-run "'`bootstrap-environment`'" "\
+     "when ready.".

--- a/scripts/setup-systemd
+++ b/scripts/setup-systemd
@@ -8,7 +8,7 @@ Requires=docker.service
 [Service]
 User=grist
 WorkingDirectory=/home/grist
-ExecStart=/usr/bin/docker compose up
+ExecStart=/usr/bin/docker compose --ansi=always up
 ExecStop=/usr/bin/docker compose down
 TimeoutStartSec=0
 Restart=always


### PR DESCRIPTION
Original commit messages:

* 139de44afa20 README: mention it can also be read online

* f681e6a28af7 README: minor clarifications

  Grist is obviously part of the distribution, and I need to clarify
  where the TLS certs are.

* a799b95717c4 README: add a section describing how to update

* 161eaa21f400 systemd: enable colour output in logs

  And give instructions in README on how to see that coloured output

* 2c8bc21c9a7e bootstrap: remove temporary docker Authelia containers

  It's cleaner than to let them stay. I would like to have a pristine
  `docker ps -a` whenever possible.

* c93b4f0a3df6 bootstrap: clarify which Authelia database is populated

  So as to not confuse it with the user database, which is populated by
  a different method.

* 0a92125f45ff reset-environment: new script

  I tried to make this script fairly conservative, as an aid to get the
  user back on track if they run into trouble when setting up Grist
  initially.

