### PR TITLE
grist: allow passing in extra environment variables to the Grist service

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -140,6 +140,20 @@ current configuration variables, if any, into the `~/.env` file. You
 may then inspect or modify your variables and re-run the bootstrap
 script again.
 
+## Additional configuration
+
+If you would like to pass any other environment variables to your
+Grist instance, you may use a supplemental file called `grist-env` to
+define any other extra variables. The syntax is the same as the
+standard `.env` file syntax.
+
+The configuration defined in `.env` takes precedence over the
+variables defined in `grist-env`.
+
+The extra variables defined in `grist-env` will only be applied to the
+Grist Docker Compose service. In particular, they will not affect
+Traefik's, Dex's, or Authelia's environment.
+
 # Updating Grist
 
 To update to the latest Grist version at any time, first stop Grist.

--- a/dist/compose.yaml
+++ b/dist/compose.yaml
@@ -59,6 +59,9 @@ services:
       # Node requires this in order to accept our manually-provided or
       # self-signed certs
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
+    env_file:
+      - path: "grist-env"
+        required: false
     restart: always
     volumes:
       # Where to store persistent data, such as documents.


### PR DESCRIPTION
This uses the following `env_file` feature of Docker Compose:

  https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/#additional-information-1