### PR TITLE
Enable an advanced Compose profile

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -143,16 +143,16 @@ script again.
 ## Additional configuration
 
 If you would like to pass any other environment variables to your
-Grist instance, you may use a supplemental file called `grist-env` to
-define any other extra variables. The syntax is the same as the
-standard `.env` file syntax.
+Grist instance, you may use a supplemental file called
+`persist/grist-env` to define any other extra variables. The syntax is
+the same as the standard `.env` file syntax.
 
 The configuration defined in `.env` takes precedence over the
-variables defined in `grist-env`.
+variables defined in `persist/grist-env`.
 
-The extra variables defined in `grist-env` will only be applied to the
-Grist Docker Compose service. In particular, they will not affect
-Traefik's, Dex's, or Authelia's environment.
+The extra variables defined in `persist/grist-env` will only be
+applied to the Grist Docker Compose service. In particular, they will
+not affect Traefik's, Dex's, or Authelia's environment.
 
 # Updating Grist
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -154,7 +154,35 @@ The extra variables defined in `persist/grist-env` will only be
 applied to the Grist Docker Compose service. In particular, they will
 not affect Traefik's, Dex's, or Authelia's environment.
 
-# Updating Grist
+## Advanced profile
+
+For advanced use cases where the authentication provided by Dex and
+Authelia is not adequate, it is possible to enable an advanced Docker
+Compose profile. This profile will only configure Traefik and start
+with a completely blank Grist configuration. To generate an advanced
+configuration, from a clean slate do
+
+```sh
+COMPOSE_PROFILES=advanced \
+DEFAULT_EMAIL=gristadmin@example.com \
+GRIST_DOMAIN=grist.example.com \
+./bin/bootstrap-environment
+```
+
+All of the Grist configuration must now be provided via the
+supplemental `persist/grist-env` file described in the previous
+section. At a bare minimum, this requires setting `APP_HOME_URL`. We
+also recommend setting the following variables to these values:
+
+* `GRIST_DEFAULT_EMAIL=${DEFAULT_EMAIL}`
+* `GRIST_SANDBOX_FLAVOR=gvisor`
+* `GRIST_ANON_PLAYGROUND=false`
+
+For further instructions on these variables as well as configuring
+authentication, consult [our documentation for
+self-hosting](https://support.getgrist.com/self-managed/).
+
+# updating Grist
 
 To update to the latest Grist version at any time, first stop Grist.
 

--- a/dist/bin/bootstrap-environment
+++ b/dist/bin/bootstrap-environment
@@ -6,6 +6,7 @@ set -e
 CONFIG_DIR=$(realpath $(dirname $0)/../config)
 ENV_DIR=$(realpath $CONFIG_DIR/..)
 
+yellow=$(tput setaf 3)
 green=$(tput setaf 2)
 red=$(tput setaf 1)
 normal=$(tput sgr0)
@@ -23,10 +24,13 @@ function setUpDirStructure {
   echo "${green}Setting up directory structure${normal}"
   mkdir -p "$SECRETS_DIR/acme"
   mkdir -p "$SECRETS_DIR/traefik-certs"
-  mkdir -p "$SECRETS_DIR/authelia-certs"
 
-  mkdir -p "$PERSIST_DIR/authelia"
   mkdir -p "$PERSIST_DIR/grist"
+
+  if [[ $COMPOSE_PROFILES == 'default' ]]; then
+    mkdir -p "$SECRETS_DIR/authelia-certs"
+    mkdir -p "$PERSIST_DIR/authelia"
+  fi
 }
 
 function setConfigVariables {
@@ -57,6 +61,11 @@ function setConfigVariables {
 }
 
 function setSecretsVariables {
+  if [[ $COMPOSE_PROFILES != "default" ]]; then
+    echo "${yellow}Skipping generation of Dex and Authelia secrets in advanced mode.${normal}"
+    return
+  fi
+
   if [[ -e $PERSIST_DIR/authelia/db.sqlite3 ]]; then
     echo "${red}Authelia's main configuration database has "\
          "already been populated. "
@@ -110,6 +119,11 @@ function setUpSelfSignedCert {
 }
 
 function setUpAdminUser {
+  if [[ $COMPOSE_PROFILES != "default" ]]; then
+    echo "${yellow}Skipping admin user credentials in advanced mode.${normal}"
+    return
+  fi
+
   dbfile=$PERSIST_DIR/users_database.yml
   if [[ -e $dbfile ]]; then
     echo "${red}Not overwriting $dbfile, file already exists${normal}"

--- a/dist/bin/bootstrap-environment
+++ b/dist/bin/bootstrap-environment
@@ -48,6 +48,7 @@ function setConfigVariables {
   export PERSIST_DIR=${PERSIST_DIR:-${ENV_DIR}/persist}
   export SECRETS_DIR=${SECRETS_DIR:-${PERSIST_DIR}/secrets}
   export DEFAULT_EMAIL=${DEFAULT_EMAIL:-test@example.org}
+  export COMPOSE_PROFILES=${COMPOSE_PROFILES:-default}
 
   export GOOGLE_CLIENT_ID
   export GOOGLE_CLIENT_SECRET

--- a/dist/bin/bootstrap-environment
+++ b/dist/bin/bootstrap-environment
@@ -126,12 +126,13 @@ setSecretsVariables
 setUpSelfSignedCert
 setUpAdminUser
 
-envsubst < $CONFIG_DIR/env-template > $PERSIST_DIR/env-vars
+ENV_FILE=$PERSIST_DIR/base-env
+envsubst < $CONFIG_DIR/env-template > $ENV_FILE
 
 # We keep everything the user might want to save in $PERSIST_DIR, so
 # we symlink the env file, the one thing that has to sit outside
 # $PERSIST_DIR.
-ln -sf $PERSIST_DIR/env-vars $ENV_DIR/.env
+ln -sf $ENV_FILE $ENV_DIR/.env
 
 # Make it prominent that the .env file exists
-ln -sf $PERSIST_DIR/env-vars $ENV_DIR/env-vars
+ln -sf $ENV_FILE $ENV_DIR/env-vars

--- a/dist/bin/reset-environment
+++ b/dist/bin/reset-environment
@@ -36,11 +36,12 @@ if [[ -e $PERSIST_DIR ]]; then
   echo "${green}Backing up persist directory to ${NEW_PERSIST_DIR}${normal}"
   mv $PERSIST_DIR $NEW_PERSIST_DIR
   PERSIST_DIR=$NEW_PERSIST_DIR
+  ENV_FILE=$PERSIST_DIR/base-env
 
-  if [[ -e $PERSIST_DIR/env-vars ]]; then
+  if [[ -e $ENV_FILE ]]; then
     echo "${green}Salvaging old environment variables as .env file${normal}"
     rm -f $ENV_DIR/.env
-    cp $PERSIST_DIR/env-vars $ENV_DIR/.env
+    cp $ENV_FILE $ENV_DIR/.env
     SALVAGED_VARS="yes"
   fi
 

--- a/dist/compose.yaml
+++ b/dist/compose.yaml
@@ -60,7 +60,7 @@ services:
       # self-signed certs
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
     env_file:
-      - path: "grist-env"
+      - path: "${PERSIST_DIR}/grist-env"
         required: false
     restart: always
     volumes:

--- a/dist/compose.yaml
+++ b/dist/compose.yaml
@@ -82,6 +82,32 @@ services:
     profiles:
       - default
 
+  # Like the grist service, but less configured, for more advanced use
+  # cases.
+  grist-advanced:
+    container_name: grist
+    image: gristlabs/grist:latest
+    user: "${USERID}:${GROUPID}"
+    environment:
+      # Node requires this in order to accept our manually-provided or
+      # self-signed certs
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
+    env_file:
+      - path: "${PERSIST_DIR}/grist-env"
+        required: true
+    restart: always
+    volumes:
+      # Where to store persistent data, such as documents.
+      - ${PERSIST_DIR}/grist:/persist
+      - ${SECRETS_DIR}/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt
+    depends_on:
+      traefik-healthcheck:
+        condition: service_healthy
+    # See note above on `links` on the default grist service.
+    links:
+      - "traefik:${GRIST_DOMAIN}"
+    profiles:
+      - advanced
 
   dex:
     restart: always

--- a/dist/compose.yaml
+++ b/dist/compose.yaml
@@ -79,6 +79,9 @@ services:
     # will use the internal Docker network when talking to each other.
     links:
       - "traefik:${GRIST_DOMAIN}"
+    profiles:
+      - default
+
 
   dex:
     restart: always
@@ -109,6 +112,8 @@ services:
     # See note above on `links` on the Grist service
     links:
       - "traefik:${GRIST_DOMAIN}"
+    profiles:
+      - default
 
   # This service is needed because the traefik container itself
   # doesn't have an openssl command, so we use this sidecar service
@@ -185,3 +190,5 @@ services:
     # See note above on `links` on the Grist service
     links:
       - "traefik:${GRIST_DOMAIN}"
+    profiles:
+      - default

--- a/dist/config/env-template
+++ b/dist/config/env-template
@@ -50,3 +50,8 @@ GROUPID=$GROUPID
 
 # This should be https://$GRIST_DOMAIN
 APP_HOME_URL=https://${GRIST_DOMAIN}
+
+# The Docker Compose profile to use. The advanced profile does not use
+# Dex or Authelia and leaves all configuration to the user in a
+# `grist-env` file.
+COMPOSE_PROFILES=$COMPOSE_PROFILES


### PR DESCRIPTION
The following creates two profiles in `compose.yaml`. The current setup that loads Traefik, Dex, Authelia, and Grist is called the `default` profile.

A new profile called `advanced` that only loads Traefik and Grist is now available. It has minimal configuration and must be configured via `persist/grist-env` parameters.

Original commit messages:

* 904f5bfa65eb dist: rename env files

  Now that there are two, I'd like to more consistently name `base-env`
  and `grist-env`, and store both in the `persist` dir.

* 591f81695b2e dist: add a `COMPOSE_PROFILES` env var to the template

  We'll use this variable for selecting different Docker Compose
  profiles.

* 400f2691023a dist: define a default Compose profile

  Dex, Authelia, and Grist will now be part of the default profile

* d8f73952c6a1 dist: only bootstrap Dex and Authelia for the default profile

  The advanced profile will not have Dex and Authelia by default

* b8485a20e131 dist: define a grist-advanced Compose service

  This service is less configured, only depends on Traefik instead of
  Dex and Authelia, and requires the `grist-env` config file.
