### PR TITLE
setup-grist-dist: add docker version tags

### DIFF
--- a/scripts/setup-grist-dist
+++ b/scripts/setup-grist-dist
@@ -32,5 +32,4 @@ echo "cat ~/.grist-motd" >> ~grist/.bashrc
 
 chown -R grist:grist ~grist
 echo 'Executing docker compose pull'
-sudo -u grist bash -c 'cd ~ && docker compose pull 2> /dev/null'
-
+sudo -u grist bash -c 'cd ~ && GRIST_DOCKER_TAG=latest TRAEFIK_DOCKER_TAG=latest DEX_DOCKER_TAG=latest AUTHELIA_DOCKER_TAG=latest docker compose pull'


### PR DESCRIPTION
When running `docker compose pull`, we now need the default tags to pull.

These tags used to be hardcoded into the `compose.yaml` file, but since they are now variables, they are not available during VM image setup.