### PR TITLE
Fix authelia integration in dex

### DIFF
--- a/dist/config/dex.yaml
+++ b/dist/config/dex.yaml
@@ -36,6 +36,7 @@ connectors:
       clientID: 'dex-local'
       clientSecret: '{{ getenv "DEX_CLIENT_SECRET" }}'
       redirectURI: '{{ getenv "APP_HOME_URL" }}/dex/callback'
+      getUserInfo: true
 
 {{ $google_client_id := getenv "GOOGLE_CLIENT_ID" }}
 {{ if ne $google_client_id "" }}


### PR DESCRIPTION
Not sure what happened, but maybe something changed in the how Authelia responds to an OIDC request. It now seems to require a separate call to provide authentication information for a user.

This instructs Dex to make that extra call.