### PR TITLE
redis: enable new service

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -13,6 +13,8 @@ Compose:
 * [Dex](https://github.com/dexidp/dex) as an OIDC provider, by default only using Authelia as a backend
   but optionally can also use Google or Microsoft as a identity
   provider
+* [Redis](https://redis.io/) as a [state
+  store](https://support.getgrist.com/self-managed/#what-is-a-state-store)
 
 # Quickstart
 
@@ -143,6 +145,7 @@ The following environment variables can be configured:
 * `DEX_DOCKER_TAG`
 * `AUTHELIA_DOCKER_TAG`
 * `TRAEFIK_DOCKER_TAG`
+* `REDIS_DOCKER_TAG`
 * `COMPOSE_PROFILES`
 
 They are documented in the generated `.env` file. 
@@ -196,13 +199,14 @@ not affect Traefik's, Dex's, or Authelia's environment.
 ## Advanced profile
 
 For advanced use cases where the authentication provided by Dex and
-Authelia is not adequate, it is possible to enable an advanced Docker
-Compose profile. This profile will only configure Traefik and start
-with a completely blank Grist configuration. To generate an advanced
-configuration, from a clean slate do
+Authelia is not adequate, it is possible to enable an advanced [Docker
+Compose profile](https://docs.docker.com/compose/how-tos/profiles/).
+This profile will only configure Traefik and Redis. It will otherwise
+start with a completely blank Grist configuration. To generate an
+advanced configuration, from a clean slate do
 
 ```sh
-COMPOSE_PROFILES=advanced \
+COMPOSE_PROFILES=advanced,redis \
 DEFAULT_EMAIL=gristadmin@example.com \
 GRIST_DOMAIN=grist.example.com \
 ./bin/bootstrap-environment
@@ -220,6 +224,21 @@ also recommend setting the following variables to these values:
 For further instructions on these variables as well as configuring
 authentication, consult [our documentation for
 self-hosting](https://support.getgrist.com/self-managed/).
+
+## Redis
+
+By default, a Redis service is included as a Compose service. This is
+enabled via [a Docker Compose
+profile](https://docs.docker.com/compose/how-tos/profiles/) named
+`redis`. The following default values hold:
+
+* `COMPOSE_PROFILE=default,redis`
+* `REDIS_URL=redis://redis`
+
+If you wish to supply your own Redis service, set
+`COMPOSE_PROFILE=default` (or `COMPOSE_PROFILE=advanced` for the
+advanced profile), and change the value of `REDIS_URL` to the URL of a
+different Redis server.
 
 # Upgrading Grist
 

--- a/dist/bin/bootstrap-environment
+++ b/dist/bin/bootstrap-environment
@@ -24,10 +24,13 @@ function setUpDirStructure {
   echo "${green}Setting up directory structure${normal}"
   mkdir -p "$SECRETS_DIR/acme"
   mkdir -p "$SECRETS_DIR/traefik-certs"
-
   mkdir -p "$PERSIST_DIR/grist"
 
-  if [[ $COMPOSE_PROFILES == 'default' ]]; then
+  if csvContains $COMPOSE_PROFILES "redis"; then
+    mkdir -p "$PERSIST_DIR/redis"
+  fi
+
+  if csvContains $COMPOSE_PROFILES "default"; then
     mkdir -p "$SECRETS_DIR/authelia-certs"
     mkdir -p "$PERSIST_DIR/authelia"
   fi
@@ -38,7 +41,14 @@ function setConfigVariables {
 
   # Don't overwrite config if it already exists
   if [[ -e $ENV_DIR/.env ]]; then
-    source .env
+    source $ENV_DIR/.env
+  fi
+
+  export PERSIST_DIR=${PERSIST_DIR:-${ENV_DIR}/persist}
+
+  # Also preserve any Grist-specific env, such as REDIS_URL
+  if [[ -e $PERSIST_DIR/grist-env ]]; then
+    source $PERSIST_DIR/grist-env
   fi
 
   export USERID=$(id -u)
@@ -49,14 +59,16 @@ function setConfigVariables {
   export GRIST_DOMAIN=${GRIST_DOMAIN:-grist.localhost}
   export HTTPS_METHOD=${HTTPS_METHOD:-manual}
   export TRAEFIK_ENABLE_DASHBOARD=${TRAEFIK_ENABLE_DASHBOARD:-false}
-  export PERSIST_DIR=${PERSIST_DIR:-${ENV_DIR}/persist}
   export SECRETS_DIR=${SECRETS_DIR:-${PERSIST_DIR}/secrets}
   export DEFAULT_EMAIL=${DEFAULT_EMAIL:-test@example.org}
-  export COMPOSE_PROFILES=${COMPOSE_PROFILES:-default}
+  export REDIS_URL=${REDIS_URL:-redis://redis}
+  export COMPOSE_PROFILES=${COMPOSE_PROFILES:-default,redis}
+
   export GRIST_DOCKER_TAG=${GRIST_DOCKER_TAG:-latest}
   export DEX_DOCKER_TAG=${DEX_DOCKER_TAG:-latest}
   export AUTHELIA_DOCKER_TAG=${AUTHELIA_DOCKER_TAG:-latest}
   export TRAEFIK_DOCKER_TAG=${TRAEFIK_DOCKER_TAG:-latest}
+  export REDIS_DOCKER_TAG=${REDIS_DOCKER_TAG:-8}
 
   export GOOGLE_CLIENT_ID
   export GOOGLE_CLIENT_SECRET
@@ -65,7 +77,7 @@ function setConfigVariables {
 }
 
 function setSecretsVariables {
-  if [[ $COMPOSE_PROFILES != "default" ]]; then
+  if ! csvContains $COMPOSE_PROFILES "default"; then
     echo "${yellow}Skipping generation of Dex and Authelia secrets in advanced mode.${normal}"
     return
   fi
@@ -123,7 +135,7 @@ function setUpSelfSignedCert {
 }
 
 function setUpAdminUser {
-  if [[ $COMPOSE_PROFILES != "default" ]]; then
+  if ! csvContains $COMPOSE_PROFILES "default"; then
     echo "${yellow}Skipping admin user credentials in advanced mode.${normal}"
     return
   fi
@@ -136,6 +148,19 @@ function setUpAdminUser {
     echo "${green}Writing initial admin user credentials${normal}"
     export PASSWORD_HASH=$(docker run --rm authelia/authelia:4 authelia crypto hash generate argon2 --password "$PASSWORD" | cut -f 2 -d' ')
     envsubst < $CONFIG_DIR/authelia/users_database.yml.template > $dbfile
+  fi
+}
+
+function csvContains {
+  local csvString="$1"
+  local targetValue="$2"
+
+  # Check if the tarxhget value, padded with commas, is present
+  # in the CSV string, also padded with commas.
+  if [[ ",${csvString}," == *",${targetValue},"* ]]; then
+    return 0
+  else
+    return 1
   fi
 }
 

--- a/dist/bin/bootstrap-environment
+++ b/dist/bin/bootstrap-environment
@@ -155,7 +155,7 @@ function csvContains {
   local csvString="$1"
   local targetValue="$2"
 
-  # Check if the tarxhget value, padded with commas, is present
+  # Check if the target value, padded with commas, is present
   # in the CSV string, also padded with commas.
   if [[ ",${csvString}," == *",${targetValue},"* ]]; then
     return 0

--- a/dist/compose.yaml
+++ b/dist/compose.yaml
@@ -51,6 +51,9 @@ services:
       GRIST_OIDC_IDP_CLIENT_SECRET: '${GRIST_OIDC_IDP_CLIENT_SECRET}'
       GRIST_OIDC_IDP_END_SESSION_ENDPOINT: '${APP_HOME_URL}/authelia'
 
+      # Enable Redis for state store
+      REDIS_URL: "redis://redis"
+
       # Working with multiple teams is possible but a little harder to
       # explain and understand, and the UI has rough edges.
       GRIST_SINGLE_ORG: ${TEAM}
@@ -70,6 +73,9 @@ services:
     depends_on:
       dex:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8484/status?db=1"]
       interval: 30s
@@ -96,6 +102,9 @@ services:
     image: "gristlabs/grist:${GRIST_DOCKER_TAG}"
     user: "${USERID}:${GROUPID}"
     environment:
+      # Enable Redis for state store
+      REDIS_URL: "redis://redis"
+
       # Node requires this in order to accept our manually-provided or
       # self-signed certs
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
@@ -110,6 +119,9 @@ services:
     depends_on:
       traefik-healthcheck:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8484/status?db=1"]
       interval: 30s
@@ -232,3 +244,19 @@ services:
       - "traefik:${GRIST_DOMAIN}"
     profiles:
       - default
+
+  redis:
+    image: "redis:${REDIS_DOCKER_TAG}"
+    container_name: redis
+    user: "${USERID}:${GROUPID}"
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    restart: unless-stopped
+    volumes:
+      - ./persist/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    profiles:
+      - redis

--- a/dist/config/env-template
+++ b/dist/config/env-template
@@ -38,6 +38,7 @@ GRIST_DOCKER_TAG=${GRIST_DOCKER_TAG}
 DEX_DOCKER_TAG=${DEX_DOCKER_TAG}
 AUTHELIA_DOCKER_TAG=${AUTHELIA_DOCKER_TAG}
 TRAEFIK_DOCKER_TAG=${TRAEFIK_DOCKER_TAG}
+REDIS_DOCKER_TAG=${REDIS_DOCKER_TAG}
 
 # Where to store data for Grist and associated services
 PERSIST_DIR=$PERSIST_DIR
@@ -57,7 +58,11 @@ GROUPID=$GROUPID
 # This should be https://$GRIST_DOMAIN
 APP_HOME_URL=https://${GRIST_DOMAIN}
 
+# If using the default Docker Redis, this should be redis://redis.
+# You may instead supply your own Redis via this URL.
+REDIS_URL=${REDIS_URL}
+
 # The Docker Compose profile to use. The advanced profile does not use
-# Dex or Authelia and leaves all configuration to the user in a
-# `grist-env` file.
+# Dex or Authelia and leaves most of the configuration to the user in
+# a `persist/grist-env` file.
 COMPOSE_PROFILES=$COMPOSE_PROFILES

--- a/grist.pkr.hcl
+++ b/grist.pkr.hcl
@@ -165,6 +165,7 @@ build {
       "scripts/install-docker",
       "scripts/setup-grist-dist",
       "scripts/setup-ufw",
+      "scripts/setup-redis",
       "scripts/setup-systemd",
       "scripts/setup-login-user",
       "scripts/cleanup",

--- a/scripts/setup-redis
+++ b/scripts/setup-redis
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Ensure vm.overcommit_memory=1. Without this parameter enabled, Redis
+# persistence can be flakey.
+echo "vm.overcommit_memory=1" > "/etc/sysctl.d/60-overcommit.conf"


### PR DESCRIPTION
The service is available for both the default and advanced profile.

I picked the default recommendation from the Docker Hub description of
the Redis image.

This also enables memory overcommit in Linux as recommended for Redis
persistence.

In order to allow users to supply their own Redis, we use Docker
Compose profiles to conditionally enable Redis (enabled by default),
and we make the `REDIS_URL` variable configurable.