### PR TITLE
Clean up document snapshots from local filesystem on upgrade

### DIFF
--- a/dist/bin/upgrade-grist
+++ b/dist/bin/upgrade-grist
@@ -2,10 +2,19 @@
 
 set -e
 
+ENV_DIR=$(realpath $(dirname $0)/..)
+PERSIST_DIR=${PERSIST_DIR:-${ENV_DIR}/persist}
+
 docker compose pull
 
 if systemctl is-active --quiet grist.service; then
-  sudo systemctl restart grist.service
+  sudo systemctl stop grist.service
+
+  # Opened snapshots don't get cleaned up automatically
+  # TODO: Grist doc workers should do this periodically
+  find $PERSIST_DIR/grist/docs -regextype posix-extended -regex '^.+~v=.+\.grist$' -delete
+
+  sudo systemctl start grist.service
 
   # Old docker images can quickly add up, so let's clean those up
   docker image prune --all --force

--- a/dist/bin/upgrade-grist
+++ b/dist/bin/upgrade-grist
@@ -8,8 +8,6 @@ PERSIST_DIR=${PERSIST_DIR:-${ENV_DIR}/persist}
 docker compose pull
 
 if systemctl is-active --quiet grist.service; then
-  sudo systemctl stop grist.service
-
   # Opened snapshots don't get cleaned up automatically
   #
   # This is a band-aid fix that doesn't account for other files that should
@@ -24,7 +22,7 @@ if systemctl is-active --quiet grist.service; then
     -regex '^.+~v=.+\.grist$' \
     -delete || true
 
-  sudo systemctl start grist.service
+  sudo systemctl restart grist.service
 
   # Old docker images can quickly add up, so let's clean those up
   docker image prune --all --force

--- a/dist/bin/upgrade-grist
+++ b/dist/bin/upgrade-grist
@@ -11,15 +11,18 @@ if systemctl is-active --quiet grist.service; then
   sudo systemctl stop grist.service
 
   # Opened snapshots don't get cleaned up automatically
-  # 
+  #
   # This is a band-aid fix that doesn't account for other files that should
   # also be removed periodically when external storage is configured, like
   # plain documents and forks. A more robust solution requires knowledge of
   # the state of external storage, and which documents are open. This implies
   # changes being needed in core Grist code, which are left for follow-up.
-  # 
+  #
   # TODO: Remove this once we have a more robust mechanism in place elsewhere.
-  find $PERSIST_DIR/grist/docs -regextype posix-extended -regex '^.+~v=.+\.grist$' -delete
+  find "$PERSIST_DIR/grist/docs" \
+    -regextype posix-extended \
+    -regex '^.+~v=.+\.grist$' \
+    -delete || true
 
   sudo systemctl start grist.service
 

--- a/dist/bin/upgrade-grist
+++ b/dist/bin/upgrade-grist
@@ -11,7 +11,14 @@ if systemctl is-active --quiet grist.service; then
   sudo systemctl stop grist.service
 
   # Opened snapshots don't get cleaned up automatically
-  # TODO: Grist doc workers should do this periodically
+  # 
+  # This is a band-aid fix that doesn't account for other files that should
+  # also be removed periodically when external storage is configured, like
+  # plain documents and forks. A more robust solution requires knowledge of
+  # the state of external storage, and which documents are open. This implies
+  # changes being needed in core Grist code, which are left for follow-up.
+  # 
+  # TODO: Remove this once we have a more robust mechanism in place elsewhere.
   find $PERSIST_DIR/grist/docs -regextype posix-extended -regex '^.+~v=.+\.grist$' -delete
 
   sudo systemctl start grist.service

--- a/dist/bin/upgrade-grist
+++ b/dist/bin/upgrade-grist
@@ -17,10 +17,7 @@ if systemctl is-active --quiet grist.service; then
   # changes being needed in core Grist code, which are left for follow-up.
   #
   # TODO: Remove this once we have a more robust mechanism in place elsewhere.
-  find "$PERSIST_DIR/grist/docs" \
-    -regextype posix-extended \
-    -regex '^.+~v=.+\.grist$' \
-    -delete || true
+  find "$PERSIST_DIR/grist/docs" -name '?*~v=?*.grist' -delete || true
 
   sudo systemctl restart grist.service
 


### PR DESCRIPTION
## Context

When external storage for documents (i.e. snapshots) is configured, Grist continues to persist local copies of documents/snapshots to the Docker volume configured for persistence. There currently isn't a mechanism in place to clean up these copies from the filesystem, which means that over time, disk usage grows as documents/snapshots are opened.

On the cloud offering of Grist at getgrist.com, this is of little consequence since workers run on ECS Fargate, with tasks that rarely exceed a week of uptime (due to weekly re-deployments for releases). If a worker exceeds disk space before then, the Fargate task will be terminated and a new one will take its place.

On Grist running in grist-pack (i.e. Grist Builder Edition), and other variants of grist-core/ee, this can be a bigger issue, particularly if the deployment environment is built around long-lived containers, as is the case with the dedicated offering on getgrist.com, which is built upon Grist Builder Edition in AWS.

## Proposal

As a partial band-aid fix, we clean up document snapshots from the local filesystem whenever the systemd service that upgrades Grist runs. These files should only be present if snapshots have been successfully configured in the past.

This fix doesn't account for plain documents or forks, and is specific to grist-pack, leaving other deployment methods without a fix. A more complete solution that accounts for documents and forks is possible, but likely requires modifications to core Grist code, so that it's agnostic to the deployment method and can provider stronger guarantees around the safety of deleting these files (e.g. is the file present in the external store, and not currently open on a worker).